### PR TITLE
NGX-344: fix fpm pool logging; add request_slowlog_timeout var

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Available variables are listed below with their default values (you can also see
 | php_config_ini_path | Default: `/etc/php.ini`
 | php_fpm_config_pool_path | Default: `/etc/php-fpm.d`
 | php_fpm_daemon | Default: `php-fpm`
-| php_fpm_site_errorlog | Default: `/var/log/php-fpm/{{ system_user }}-error.log`
+| php_request_slowlog_timeout | Default: `0`
+| php_fpm_site_errorlog | Default: `/home/{{ system_user }}/logs/{{ site_domain | replace (".", "_") }}.php.error.log`
 | php_fpm_slowlog | Default: `/var/log/php-fpm/{{ system_user }}-slow.log`
 | php_fpm_socket_path | Default: `/var/run/php-fpm/{{ system_user }}.sock`
 | php_packages | The list of PHP packages to install.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ php_config_ini_path: /etc/php.ini
 php_fpm_config_path: /etc/php-fpm.conf
 php_fpm_config_pool_path: /etc/php-fpm.d
 php_fpm_daemon: php-fpm
-php_fpm_site_errorlog: /var/log/php-fpm/{{ system_user }}-error.log
+php_fpm_site_errorlog: /home/{{ system_user }}/logs/{{ site_domain | replace(".", "_") }}.php.error.log
 php_fpm_slowlog: /var/log/php-fpm/{{ system_user }}-slow.log
 php_fpm_socket_path: /var/run/php-fpm/{{ system_user }}.sock
 php_systemd_restart: false


### PR DESCRIPTION
- Resolve error logging failures; Configure error logging to path which system_user can write to.
- Add request_slowlog_timeout variable for the ability to log slow fpm executions. A value of '0' means 'Off'. Available units: s(econds)(default), m(inutes), h(ours), or d(ays). Default value: 0.
