### PR TITLE
NGX-343: adjust systemd restart default behavior to not automatically restart

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,8 +65,9 @@
 - name: Include systemd restart configuration
   include: systemd.yml
   when: >-
-    - php_systemd_restart|default(false) or systemd_restart|default(false)
-    - systemd_restart_setting is defined
+    ( php_systemd_restart|default(False)
+    or systemd_restart|default(False) )
+    and systemd_restart_setting is defined
 
 - name: Start and enable php-fpm service
   service:


### PR DESCRIPTION
- The default behavior should be that systemd restart configuration is not applied.