### PR TITLE
Gather package_facts if not defined

### DIFF
--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -1,4 +1,10 @@
 ---
+- name: Ensure we have package facts
+  ansible.builtin.package_facts:
+    manager: auto
+  when:
+    - ansible_facts.packages is not defined
+
 - name: Set installed PHP version
   vars:
     package: php-fpm


### PR DESCRIPTION
When calling role, the package_facts variable may not always be available - if it is not defined, gather them before continuing.