### PR TITLE
Add php_fpm_binary variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Available variables are listed below with their default values (you can also see
 | Variable | Description |
 | -------- | ----------- |
 | php_config_ini_path | Default: `/etc/php.ini`
+| php_fpm_binary | Default: `php-fpm`. The name of the binary for the php-fpm service
 | php_fpm_config_pool_path | Default: `/etc/php-fpm.d`
 | php_fpm_daemon | Default: `php-fpm`
 | php_request_slowlog_timeout | Default: `0`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ php_config_ini_path: /etc/php.ini
 php_fpm_config_path: /etc/php-fpm.conf
 php_fpm_config_pool_path: /etc/php-fpm.d
 php_fpm_daemon: php-fpm
+php_fpm_binary: php-fpm
 php_fpm_site_errorlog: /home/{{ system_user }}/logs/{{ site_domain | replace(".", "_") }}.php.error.log
 php_fpm_slowlog: /var/log/php-fpm/{{ system_user }}-slow.log
 php_fpm_socket_path: /var/run/php-fpm/{{ system_user }}.sock

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,7 +6,7 @@ driver:
   name: docker
 
 platforms:
-  - name: "molecule-ansible-role-mysql"
+  - name: "molecule-ansible-role-php_fpm"
     image: ${MOLECULE_IMAGE:-geerlingguy/docker-ubuntu2204-ansible:latest}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -24,6 +24,7 @@
       - php_version
       - php_version_flat
       - php_config_ini_path
+      - php_fpm_binary
       - php_fpm_config_path
       - php_fpm_daemon
       - php_ini_memory_limit

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -2,7 +2,7 @@
 php_config_ini_path: /etc/php/{{ php_version }}/fpm/php.ini
 php_fpm_config_path: /etc/php/{{ php_version }}/fpm/php-fpm.conf
 php_fpm_config_pool_path: /etc/php/{{ php_version }}/fpm/pool.d
-php_fpm_daemon: php{{ php_version }}-fpm
+php_fpm_daemon: php-fpm{{ php_version }}
 php_fpm_site_errorlog: /home/{{ system_user }}/logs/{{ site_domain | replace(".", "_") }}.php.error.log
 php_fpm_slowlog: /var/log/php{{ php_version }}-fpm-slow.log
 php_fpm_socket_path: /var/run/php/{{ system_user }}.sock

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -2,7 +2,8 @@
 php_config_ini_path: /etc/php/{{ php_version }}/fpm/php.ini
 php_fpm_config_path: /etc/php/{{ php_version }}/fpm/php-fpm.conf
 php_fpm_config_pool_path: /etc/php/{{ php_version }}/fpm/pool.d
-php_fpm_daemon: php-fpm{{ php_version }}
+php_fpm_daemon: php{{ php_version }}-fpm
+php_fpm_binary: php-fpm{{ php_version }}
 php_fpm_site_errorlog: /home/{{ system_user }}/logs/{{ site_domain | replace(".", "_") }}.php.error.log
 php_fpm_slowlog: /var/log/php{{ php_version }}-fpm-slow.log
 php_fpm_socket_path: /var/run/php/{{ system_user }}.sock


### PR DESCRIPTION
This variable allows us to execute a syntax check against the php-fpm configuration.

Also fix a typo for the name of the instance created by molecule in molecule/molecule.yml.