### PR TITLE
NGX-780: Introduce siteurl, phpversion tags

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # requirements.txt
 
 ansible-lint
-ansible>=6,<7
+ansible
 molecule-plugins[docker]
-molecule>=5,<6
+molecule
 pre-commit

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -4,6 +4,7 @@
     manager: auto
   when:
     - ansible_facts.packages is not defined
+  tags: phpversion
 
 - name: Set installed PHP version
   vars:
@@ -13,6 +14,7 @@
     php_version_installed_flat: "{{ ansible_facts.packages[package][0].version.split('.')[0:2] | join('.') | replace('.', '') }}"
   when:
     - package in ansible_facts.packages.keys()
+  tags: phpversion
 
 - name: Include Debian vars
   ansible.builtin.include_vars: "debian.yml"
@@ -126,8 +128,10 @@
   when:
     - php_version_installed is defined
     - php_version != php_version_installed
+  tags: phpversion
 
 - name: Remove php-sodium when PHP 5.6
   ansible.builtin.set_fact:
     php_packages: "{{ php_packages | reject('search', 'php-sodium') | list }}"
   when: php_version == '5.6'
+  tags: phpversion

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
 
 - name: Setup package repositories
   ansible.builtin.include_tasks: "packages/{{ ansible_os_family | lower }}.yml"
+  tags: phpversion
 
 - name: Remove PHP packages (if version changing)
   ansible.builtin.package:
@@ -12,11 +13,13 @@
   when:
     - php_version_switch is defined
     - php_version_switch
+  tags: phpversion
 
 - name: Install PHP packages
   ansible.builtin.package:
     name: "{{ php_packages }}"
     state: present
+  tags: phpversion
 
 - name: Configure php.ini
   ansible.builtin.template:
@@ -33,6 +36,7 @@
     regexp: "^;rlimit_files.*"
     line: rlimit_files = {{ php_ini_rlimit_files }}
   notify: Restart php-fpm
+  tags: phpversion
 
 - name: Check if Apache dirs are present
   ansible.builtin.stat:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Set and sanitize facts
   ansible.builtin.include_tasks: facts.yml
+  tags: phpversion
 
 - name: Setup package repositories
   ansible.builtin.include_tasks: "packages/{{ ansible_os_family | lower }}.yml"
@@ -29,6 +30,7 @@
     group: root
     mode: "0644"
   notify: Restart php-fpm
+  tags: phpversion
 
 - name: Configure rlimit_files in php-fpm.conf
   ansible.builtin.lineinfile:

--- a/tasks/packages/redhat.yml
+++ b/tasks/packages/redhat.yml
@@ -47,6 +47,7 @@
   when:
     - php_version_switch | default(false)
     - php_version_switch is defined
+  tags: phpversion
 
 # FIXME: Find a better way to enable a repo prior to installing packages
 # FIXME: Idempotence is broken on this task. Anything we can hook onto?
@@ -62,3 +63,4 @@
       {{ php_version_flat if version | int == 7
       else php_version }}
     version: "{{ ansible_distribution_major_version }}"
+  tags: phpversion


### PR DESCRIPTION
There are two actions which can be performed against a target server from the application interface. The two actions are changing the Site URL and changin the PHP Version. Both of these tasks do not require the playbook to be ran in its entirety. These new tags isolate the tasks required to complete each action. This improves speed and interaction with the server playbook.