### PR TITLE
NGX-803: Empty contents of www.conf

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,6 +55,15 @@
   notify: Restart php-fpm
   when: apache.stat.exists
 
+- name: Empty contents of php-fpm www.conf
+  ansible.builtin.copy:
+    dest: "{{ php_fpm_config_pool_path }}/www.conf"
+    owner: root
+    group: root
+    mode: "0644"
+    content: ""
+  notify: Restart php-fpm
+
 - name: Include systemd restart configuration
   ansible.builtin.include_tasks: systemd.yml
   when: >-


### PR DESCRIPTION
Just erase there contents and leave the empty file in place. Next time there's an update package manager (e.g. yum) will just put the default file in the directory as www.conf.rpmnew and it won't be parsed.