### PR TITLE
NGX-869: Disable expose_php in /etc/php.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Available variables are listed below with their default values (you can also see
 | Variable | Description |
 | -------- | ----------- |
 | php_ini_allow_url_fopen | Default: `true`
+| php_ini_expose_php | Default: `false`
 | php_ini_max_execution_time | Default: `60`
 | php_ini_max_input_vars | Default: `6200`
 | php_ini_memory_limit | Default: `512M`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ php_fpm_daemon: php-fpm
 php_fpm_binary: php-fpm
 php_fpm_site_errorlog: /home/{{ system_user }}/logs/{{ site_domain | replace(".", "_") }}.php.error.log
 php_fpm_slowlog: /var/log/php-fpm/{{ system_user }}-slow.log
-php_fpm_socket_path: /var/run/php-fpm/{{ system_user }}.sock
+php_fpm_socket_path: "/var/run/php-fpm/{{ system_user }}.sock"
 php_systemd_restart: false
 systemd_restart_setting: on-failure
 
@@ -69,6 +69,7 @@ php_conf_soap_wsdl_cache_dir: /var/lib/php/wsdlcache
 
 php_ini_allow_url_fopen: true
 php_ini_rlimit_files: 16384
+php_ini_expose_php: false
 php_ini_max_execution_time: 60
 php_ini_max_input_vars: 6200
 php_ini_memory_limit: 512M

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ php_fpm_daemon: php-fpm
 php_fpm_binary: php-fpm
 php_fpm_site_errorlog: /home/{{ system_user }}/logs/{{ site_domain | replace(".", "_") }}.php.error.log
 php_fpm_slowlog: /var/log/php-fpm/{{ system_user }}-slow.log
-php_fpm_socket_path: "/var/run/php-fpm/{{ system_user }}.sock"
+php_fpm_socket_path: /var/run/php-fpm/{{ system_user }}.sock
 php_systemd_restart: false
 systemd_restart_setting: on-failure
 

--- a/templates/etc/php.ini.j2
+++ b/templates/etc/php.ini.j2
@@ -3,6 +3,7 @@
 
 [core]
 allow_url_fopen = {{ 'on' if php_ini_allow_url_fopen else 'off' }}
+expose_php = {{ 'on' if php_ini_expose_php else 'off' }}
 max_execution_time = {{ php_ini_max_execution_time }}
 max_input_vars = {{ php_ini_max_input_vars }}
 memory_limit = {{ php_ini_memory_limit }}


### PR DESCRIPTION
- Disable expose_php in /etc/php.ini - See https://www.php.net/manual/en/ini.core.php#ini.expose-php
- Adds the `php_ini_expose_php` variable